### PR TITLE
Add Opacity Xray

### DIFF
--- a/src/main/java/me/dustin/jex/event/render/EventBufferQuadAlpha.java
+++ b/src/main/java/me/dustin/jex/event/render/EventBufferQuadAlpha.java
@@ -1,0 +1,19 @@
+package me.dustin.jex.event.render;
+
+import me.dustin.events.core.Event;
+
+public class EventBufferQuadAlpha extends Event {
+    private int alpha;
+
+    public EventBufferQuadAlpha(int alpha) {
+        this.alpha = alpha;
+    }
+
+    public int getAlpha() {
+        return alpha;
+    }
+
+    public void setAlpha(int alpha) {
+        this.alpha = alpha;
+    }
+}

--- a/src/main/java/me/dustin/jex/event/render/EventGetRenderLayer.java
+++ b/src/main/java/me/dustin/jex/event/render/EventGetRenderLayer.java
@@ -1,0 +1,27 @@
+package me.dustin.jex.event.render;
+
+import me.dustin.events.core.Event;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.RenderLayer;
+
+public class EventGetRenderLayer extends Event {
+    private BlockState state;
+    private RenderLayer renderLayer;
+
+    public EventGetRenderLayer(BlockState state, RenderLayer renderLayer) {
+        this.state = state;
+        this.renderLayer = renderLayer;
+    }
+
+    public BlockState getState() {
+        return state;
+    }
+
+    public RenderLayer getRenderLayer() {
+        return renderLayer;
+    }
+
+    public void setRenderLayer(RenderLayer renderLayer) {
+        this.renderLayer = renderLayer;
+    }
+}

--- a/src/main/java/me/dustin/jex/event/render/EventGetRenderLayer.java
+++ b/src/main/java/me/dustin/jex/event/render/EventGetRenderLayer.java
@@ -8,9 +8,8 @@ public class EventGetRenderLayer extends Event {
     private BlockState state;
     private RenderLayer renderLayer;
 
-    public EventGetRenderLayer(BlockState state, RenderLayer renderLayer) {
+    public EventGetRenderLayer(BlockState state) {
         this.state = state;
-        this.renderLayer = renderLayer;
     }
 
     public BlockState getState() {

--- a/src/main/java/me/dustin/jex/event/render/EventIsBlockOpaque.java
+++ b/src/main/java/me/dustin/jex/event/render/EventIsBlockOpaque.java
@@ -1,0 +1,19 @@
+package me.dustin.jex.event.render;
+
+import me.dustin.events.core.Event;
+
+public class EventIsBlockOpaque extends Event {
+    private boolean opaque;
+
+    public EventIsBlockOpaque(boolean opaque) {
+        this.opaque = opaque;
+    }
+
+    public boolean isOpaque() {
+        return opaque;
+    }
+
+    public void setOpaque(boolean opaque) {
+        this.opaque = opaque;
+    }
+}

--- a/src/main/java/me/dustin/jex/load/mixin/MixinAbstractBlockstate.java
+++ b/src/main/java/me/dustin/jex/load/mixin/MixinAbstractBlockstate.java
@@ -1,6 +1,7 @@
 package me.dustin.jex.load.mixin;
 
 import me.dustin.jex.event.render.EventBlockBrightness;
+import me.dustin.jex.event.render.EventIsBlockOpaque;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import org.spongepowered.asm.mixin.Final;
@@ -10,12 +11,16 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(AbstractBlock.AbstractBlockState.class)
+@Mixin(value = AbstractBlock.AbstractBlockState.class, remap = false)
 public abstract class MixinAbstractBlockstate {
 
     @Shadow
     @Final
     private int luminance;
+
+    @Shadow
+    @Final
+    private boolean opaque;
 
     @Shadow
     public abstract Block getBlock();
@@ -26,4 +31,9 @@ public abstract class MixinAbstractBlockstate {
         cir.setReturnValue(eventBlockBrightness.getBrightness());
     }
 
+    @Inject(method = "isOpaque", at = @At("HEAD"), cancellable = true)
+    public void isOpaque(CallbackInfoReturnable<Boolean> cir) {
+        EventIsBlockOpaque eventIsBlockOpaque = new EventIsBlockOpaque(opaque).run();
+        cir.setReturnValue(eventIsBlockOpaque.isOpaque());
+    }
 }

--- a/src/main/java/me/dustin/jex/load/mixin/MixinAbstractQuadRenderer.java
+++ b/src/main/java/me/dustin/jex/load/mixin/MixinAbstractQuadRenderer.java
@@ -1,0 +1,19 @@
+package me.dustin.jex.load.mixin;
+
+import me.dustin.jex.event.render.EventBufferQuadAlpha;
+import net.fabricmc.fabric.impl.client.indigo.renderer.render.AbstractQuadRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Pseudo
+@Mixin(value = AbstractQuadRenderer.class, remap = false)
+public class MixinAbstractQuadRenderer {
+    @ModifyArg(method = "bufferQuad(Lnet/minecraft/client/render/VertexConsumer;Lnet/fabricmc/fabric/impl/client/indigo/renderer/mesh/MutableQuadViewImpl;Lnet/minecraft/util/math/Matrix4f;ILnet/minecraft/util/math/Matrix3f;Lnet/minecraft/util/math/Vec3f;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/VertexConsumer;color(IIII)Lnet/minecraft/client/render/VertexConsumer;"), index = 3)
+    private static int colorAlpha(int alpha) {
+        EventBufferQuadAlpha eventBufferQuadAlpha = new EventBufferQuadAlpha(alpha).run();
+        return eventBufferQuadAlpha.getAlpha();
+    }
+}

--- a/src/main/java/me/dustin/jex/load/mixin/MixinRenderLayers.java
+++ b/src/main/java/me/dustin/jex/load/mixin/MixinRenderLayers.java
@@ -1,0 +1,22 @@
+package me.dustin.jex.load.mixin;
+
+import me.dustin.jex.event.render.EventGetRenderLayer;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderLayers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(RenderLayers.class)
+public class MixinRenderLayers {
+    @Inject(method = "getBlockLayer", at = @At("TAIL"), cancellable = true)
+    private static void getBlockLayer(BlockState state, CallbackInfoReturnable<RenderLayer> cir) {
+        EventGetRenderLayer eventGetRenderLayer = new EventGetRenderLayer(state, cir.getReturnValue()).run();
+        if (eventGetRenderLayer.isCancelled()) {
+            cir.setReturnValue(eventGetRenderLayer.getRenderLayer());
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/java/me/dustin/jex/load/mixin/MixinRenderLayers.java
+++ b/src/main/java/me/dustin/jex/load/mixin/MixinRenderLayers.java
@@ -11,9 +11,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(RenderLayers.class)
 public class MixinRenderLayers {
-    @Inject(method = "getBlockLayer", at = @At("TAIL"), cancellable = true)
+    @Inject(method = "getBlockLayer", at = @At("HEAD"), cancellable = true)
     private static void getBlockLayer(BlockState state, CallbackInfoReturnable<RenderLayer> cir) {
-        EventGetRenderLayer eventGetRenderLayer = new EventGetRenderLayer(state, cir.getReturnValue()).run();
+        EventGetRenderLayer eventGetRenderLayer = new EventGetRenderLayer(state).run();
         if (eventGetRenderLayer.isCancelled()) {
             cir.setReturnValue(eventGetRenderLayer.getRenderLayer());
             cir.cancel();

--- a/src/main/resources/jex.mixins.json
+++ b/src/main/resources/jex.mixins.json
@@ -4,6 +4,8 @@
   "package": "me.dustin.jex.load.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "MixinAbstractQuadRenderer",
+    "MixinRenderLayers"
   ],
   "client": [
     "MixinAbstractBlockstate",

--- a/src/main/resources/jex.mixins.json
+++ b/src/main/resources/jex.mixins.json
@@ -4,12 +4,11 @@
   "package": "me.dustin.jex.load.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "MixinAbstractQuadRenderer",
-    "MixinRenderLayers"
   ],
   "client": [
     "MixinAbstractBlockstate",
     "MixinAbstractClientPlayerEntity",
+    "MixinAbstractQuadRenderer",
     "MixinBackgroundRenderer",
     "MixinBlock",
     "MixinBlockEntityRenderDispatcher",
@@ -47,6 +46,7 @@
     "MixinPlayerEntity",
     "MixinPlayerEntityRenderer",
     "MixinProjectileEntity",
+    "MixinRenderLayers",
     "MixinRenderTickCounter",
     "MixinScreen",
     "MixinSignEditScreen",


### PR DESCRIPTION
Adds an Opacity Xray with adjustable alpha value for blocks not in the xray's visible block list.
Compatible with the Indigo Renderer, the same methodology for adjusting a quad's alpha levels should be applied to Sodium whenever that gets updated.