### PR TITLE
Add Item Durability option to HUD

### DIFF
--- a/src/main/java/me/dustin/jex/event/render/EventRender2DItem.java
+++ b/src/main/java/me/dustin/jex/event/render/EventRender2DItem.java
@@ -1,0 +1,41 @@
+package me.dustin.jex.event.render;
+
+import me.dustin.events.core.Event;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.item.ItemStack;
+
+public class EventRender2DItem extends Event {
+    private final ItemRenderer itemRenderer;
+    private final TextRenderer fontRenderer;
+    private final ItemStack stack;
+    private final int x, y;
+
+    public EventRender2DItem(ItemRenderer itemRenderer, TextRenderer fontRenderer, ItemStack stack, int x, int y) {
+        this.itemRenderer = itemRenderer;
+        this.fontRenderer = fontRenderer;
+        this.stack = stack;
+        this.x = x;
+        this.y = y;
+    }
+
+    public ItemRenderer getItemRenderer() {
+        return this.itemRenderer;
+    }
+
+    public final TextRenderer getFontRenderer() {
+        return this.fontRenderer;
+    }
+
+    public final ItemStack getStack() {
+        return this.stack;
+    }
+
+    public final int getX() {
+        return this.x;
+    }
+
+    public final int getY() {
+        return  this.y;
+    }
+}

--- a/src/main/java/me/dustin/jex/load/mixin/MixinItemRenderer.java
+++ b/src/main/java/me/dustin/jex/load/mixin/MixinItemRenderer.java
@@ -2,9 +2,11 @@ package me.dustin.jex.load.mixin;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
+import me.dustin.jex.event.render.EventRender2DItem;
 import me.dustin.jex.event.render.EventRenderItem;
 import me.dustin.jex.load.impl.IItemRenderer;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.DiffuseLighting;
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumerProvider;
@@ -49,6 +51,12 @@ public abstract class MixinItemRenderer implements IItemRenderer {
     public void postRenderItem(ItemStack stack, ModelTransformation.Mode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (((EventRenderItem)new EventRenderItem(matrices, stack, renderMode, EventRenderItem.RenderTime.POST, leftHanded).run()).isCancelled())
             ci.cancel();
+    }
+
+    @Inject(method = "renderGuiItemOverlay(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V", at = @At("RETURN"), cancellable = true)
+    public void renderGuiItemOverlay(TextRenderer renderer, ItemStack stack, int x, int y, String countLabel, CallbackInfo ci) {
+        ItemRenderer instance = (ItemRenderer) (Object) this;
+        EventRender2DItem eventRender2DItem = new EventRender2DItem(instance, renderer, stack, x, y).run();
     }
 
     @Override


### PR DESCRIPTION
Adds an item durability open to the HUD which shows the number of uses currently left on the item in your hotbar or inventory.
Static color option (White) if for whatever reason people don't like the text's color matching the durability bar