### PR TITLE
Rework queries for Jex version and build metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ def _git_data = "git rev-parse --short HEAD".execute().text.trim()
 def _git_ref = "git symbolic-ref HEAD".execute().text.trim().split('/').last()
 def revision = _git_tag.contains(_git_data) ? _git_data : _git_tag
 
-project.mod_version = "${_git_ref}@${revision}".toString()
+project.build_version = "${_git_ref}@${revision}".toString()
 
 version = project.mod_version
 group = project.maven_group
@@ -55,7 +55,7 @@ processResources {
     inputs.property "version", project.version
 
     filesMatching("fabric.mod.json") {
-        expand "version": project.version
+        expand ('version': project.version, 'buildVersion': project.build_version)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ loader_version=0.11.6
 fabric_version=0.36.0+1.17
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=0.3.4
 maven_group=net.fabricmc
 archives_base_name=jex-client
+build_version=main@abcdefg

--- a/src/main/java/me/dustin/jex/JexClient.java
+++ b/src/main/java/me/dustin/jex/JexClient.java
@@ -36,6 +36,7 @@ import me.dustin.jex.helper.world.WorldHelper;
 import me.dustin.jex.option.OptionManager;
 import me.dustin.jex.update.UpdateManager;
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.sound.SoundEvents;
@@ -47,7 +48,6 @@ import java.util.Arrays;
 
 public enum JexClient {
     INSTANCE;
-    private String version = "0.3.4";
     private boolean autoSaveModules = false;
     private boolean soundOnLaunch = true;
 
@@ -117,12 +117,16 @@ public enum JexClient {
         }
     }
 
-    public String getVersion() {
-        return version;
+    public ModContainer getModContainer() {
+        return FabricLoader.getInstance().getModContainer("jex").orElse(null);
     }
 
-    public String getMetaDataVersion() {
-        return FabricLoader.getInstance().getModContainer("jex").get().getMetadata().getVersion().getFriendlyString();
+    public String getVersion() {
+        return this.getModContainer().getMetadata().getVersion().getFriendlyString();
+    }
+
+    public String getBuildMetaData() {
+        return this.getModContainer().getMetadata().getCustomValue("buildVersion").getAsString();
     }
 
     public boolean isAutoSaveEnabled() {

--- a/src/main/java/me/dustin/jex/JexClient.java
+++ b/src/main/java/me/dustin/jex/JexClient.java
@@ -122,7 +122,11 @@ public enum JexClient {
     }
 
     public String getVersion() {
-        return this.getModContainer().getMetadata().getVersion().getFriendlyString();
+        if(this.getModContainer().getMetadata().getVersion().getFriendlyString().equals("${version}")) {
+            return "0.0.0-unknown";
+        } else {
+            return this.getModContainer().getMetadata().getVersion().getFriendlyString();
+        }
     }
 
     public String getBuildMetaData() {

--- a/src/main/java/me/dustin/jex/JexClient.java
+++ b/src/main/java/me/dustin/jex/JexClient.java
@@ -35,6 +35,7 @@ import me.dustin.jex.helper.player.PlayerHelper;
 import me.dustin.jex.helper.world.WorldHelper;
 import me.dustin.jex.option.OptionManager;
 import me.dustin.jex.update.UpdateManager;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.sound.PositionedSoundInstance;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.sound.SoundEvents;
@@ -118,6 +119,10 @@ public enum JexClient {
 
     public String getVersion() {
         return version;
+    }
+
+    public String getMetaDataVersion() {
+        return FabricLoader.getInstance().getModContainer("jex").get().getMetadata().getVersion().getFriendlyString();
     }
 
     public boolean isAutoSaveEnabled() {

--- a/src/main/java/me/dustin/jex/feature/impl/render/Hud.java
+++ b/src/main/java/me/dustin/jex/feature/impl/render/Hud.java
@@ -29,6 +29,7 @@ import me.dustin.jex.feature.core.enums.FeatureCategory;
 import me.dustin.jex.helper.world.WorldHelper;
 import me.dustin.jex.option.annotate.Op;
 import me.dustin.jex.option.annotate.OpChild;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.ChatScreen;
@@ -119,6 +120,8 @@ public class Hud extends Feature {
     public boolean biome = true;
     @OpChild(name = "Player Count", parent = "Info")
     public boolean playerCount = true;
+    @OpChild(name = "Build Info", parent = "Info")
+    public boolean buildInfo = false;
     @OpChild(name = "Yaw/Pitch", parent = "Info")
     public boolean yawAndPitch = true;
     @OpChild(name = "Direction", parent = "Info")
@@ -521,6 +524,11 @@ public class Hud extends Feature {
         if (playerCount) {
             String str = String.format("Player Count\247f: \2477%d", Wrapper.INSTANCE.getMinecraft().getNetworkHandler().getPlayerList() == null ? 0 : Wrapper.INSTANCE.getMinecraft().getNetworkHandler().getPlayerList().size());
             FontHelper.INSTANCE.drawWithShadow(eventRender2D.getMatrixStack(), str, 2, startY + (10 * infoCount), ColorHelper.INSTANCE.getClientColor());
+            infoCount++;
+        }
+        if (buildInfo) {
+            String projectVersion =  String.format("%s %s", JexClient.INSTANCE.getMetaDataVersion().equals("${version}") ? "Build Error" : JexClient.INSTANCE.getMetaDataVersion(), FabricLoader.getInstance().isDevelopmentEnvironment() ? "(Dev)" : "(Release)");
+            FontHelper.INSTANCE.drawWithShadow(eventRender2D.getMatrixStack(), String.format("Build\247f: \2477%s", projectVersion), 2, startY + (10 * infoCount), ColorHelper.INSTANCE.getClientColor());
             infoCount++;
         }
     }

--- a/src/main/java/me/dustin/jex/feature/impl/render/Hud.java
+++ b/src/main/java/me/dustin/jex/feature/impl/render/Hud.java
@@ -527,8 +527,8 @@ public class Hud extends Feature {
             infoCount++;
         }
         if (buildInfo) {
-            String projectVersion =  String.format("%s %s", JexClient.INSTANCE.getMetaDataVersion().equals("${version}") ? "Build Error" : JexClient.INSTANCE.getMetaDataVersion(), FabricLoader.getInstance().isDevelopmentEnvironment() ? "(Dev)" : "(Release)");
-            FontHelper.INSTANCE.drawWithShadow(eventRender2D.getMatrixStack(), String.format("Build\247f: \2477%s", projectVersion), 2, startY + (10 * infoCount), ColorHelper.INSTANCE.getClientColor());
+            String buildMetaData =  String.format("%s %s", JexClient.INSTANCE.getBuildMetaData().equals("${buildVersion}") ? "Built Improperly" : JexClient.INSTANCE.getBuildMetaData(), FabricLoader.getInstance().isDevelopmentEnvironment() ? "(Dev)" : "(Release)");
+            FontHelper.INSTANCE.drawWithShadow(eventRender2D.getMatrixStack(), String.format("Build\247f: \2477%s", buildMetaData), 2, startY + (10 * infoCount), ColorHelper.INSTANCE.getClientColor());
             infoCount++;
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,5 +30,8 @@
   },
   "suggests": {
     "flamingo": "*"
+  },
+  "custom": {
+    "buildVersion": "${buildVersion}"
   }
 }


### PR DESCRIPTION
Since the last PR was a bit hasty. 

Set `buildVersion` as a custom value to be parsed by fabric, and set by Gradle when built, rather than using the actual mod version.
Changed `getVersion()` so we query the mod metadata to find out the version (gradle.properties) rather than relying on a static variable in the main class.

If you're not using the runClient gradle task, and instead using an IDE App task like "Minecraft Client" in IntelliJ, Gradle doesn't properly add metadata for the mod. So the version will show up as `${version}`